### PR TITLE
Add link to documentation in markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@
 - [Budgets using Fava](https://fava.pythonanywhere.com/example-beancount-file/help/budgets/)
 - [Beancount Oneliner](https://pythonhosted.org/beancount-oneliner/)
 - [Reports on portfolio asset allocation in Beancount](https://github.com/ghislainbourgeois/beancount_portfolio_allocation/)
+- [Documentation in Markdown](https://github.com/xuhcc/beancount-docs)


### PR DESCRIPTION
https://github.com/xuhcc/beancount-docs | https://xuhcc.github.io/beancount-docs/