### PR TITLE
Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@
 
 - [Homepage](http://furius.ca/beancount)
 - [Bitbucket](https://bitbucket.org/blais/beancount/)
-- [Beancount Documentation Index](https://docs.google.com/document/d/1RaondTJCS_IUPBHFNdT8oqFKJjVJDsfsn6JEjBG04eA/edit)
+- Beancount Documentation
+    - [Google Docs](https://docs.google.com/document/d/1RaondTJCS_IUPBHFNdT8oqFKJjVJDsfsn6JEjBG04eA/edit)
+    - [GitHub Pages](https://beancount.github.io/docs/)
 
 ## UI
 
@@ -116,4 +118,3 @@
 - [Budgets using Fava](https://fava.pythonanywhere.com/example-beancount-file/help/budgets/)
 - [Beancount Oneliner](https://pythonhosted.org/beancount-oneliner/)
 - [Reports on portfolio asset allocation in Beancount](https://github.com/ghislainbourgeois/beancount_portfolio_allocation/)
-- [Documentation in Markdown](https://github.com/xuhcc/beancount-docs)


### PR DESCRIPTION
Markdown version has moved to https://github.com/beancount/docs/ and is now official.