### PR TITLE
Google Docs is primary documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ system — ideal for plain text accounting users and Python software developers.
 - [Homepage](https://beancount.github.io/)
 - [Source Code](https://github.com/beancount/beancount)
 - Documentation
-    - [GitHub Pages](https://beancount.github.io/docs/)
     - [Google Docs](https://docs.google.com/document/d/1RaondTJCS_IUPBHFNdT8oqFKJjVJDsfsn6JEjBG04eA/edit)
+    - [GitHub Pages](https://beancount.github.io/docs/) ([generated](https://github.com/beancount/docs) from Google Docs)
 - [External Contributions to Beancount](https://beancount.github.io/docs/external_contributions.html)
 
 ## Books


### PR DESCRIPTION
Hello, I maintain the https://beancount.github.io/docs/ website. Sometimes people think that it is the primary documentation site, and suggest changes. However, this website is generated automatically from the original Google Docs.

This PR clarifies that Google Docs is the original.