### PR TITLE
add importers link for Crédit Mutuel/Fortuneo (french banks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ system — ideal for plain text accounting users and Python software developers.
 
 - [Caisse d'Epargne](https://github.com/ArthurFDLR/beancount-ce)
 - [Boursorama, Amex, ... ](https://github.com/grostim/Beancount-myTools)
+- [Fortuneo, Crédit Mutuel](https://github.com/vrischmann/beancount-importers)
 
 ### India
 - [SBI/BOI/PAYTM/HSBC/ICICI](https://github.com/dumbPy/beancount-importers-india)


### PR DESCRIPTION
Hi,

I found this repo via Hacker News today, thanks for the resources !

I've been using Beancount with two french banks for years now with importers I wrote at the time, I figure they can be useful to other french beancount users.

This PR adds a link to my repo containing the importers.